### PR TITLE
fix: improve error for missing desc

### DIFF
--- a/options.go
+++ b/options.go
@@ -37,7 +37,7 @@ func printArgs(buf *bytes.Buffer, cmd *cobra.Command) error {
 				line := fmt.Sprintf("   * - %s\n     - string\n     - %v\n     - %s", arg, required, description)
 				buf.WriteString(line)
 			} else {
-				return fmt.Errorf("%w: %s", ErrMissingDescription, arg)
+				return fmt.Errorf("%w: %s - %s", ErrMissingDescription, cmd.Use, arg)
 			}
 		}
 		buf.WriteString("\n\n")


### PR DESCRIPTION
## Proposed changes

While fixing errors on mongocli finding the problematic command turned out to be a bit harder than expected, this makes it a bit easier by giving me the command name instead of just the arg

## Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code
