### PR TITLE
Fix indent for examples

### DIFF
--- a/cobra2snooty.go
+++ b/cobra2snooty.go
@@ -116,7 +116,7 @@ func GenDocs(cmd *cobra.Command, w io.Writer) error {
 
 	if len(cmd.Example) > 0 {
 		buf.WriteString(examplesHeader)
-		buf.WriteString(fmt.Sprintf("\n%s\n\n", indentString(cmd.Example, " ")))
+		buf.WriteString(fmt.Sprintf("\n%s\n\n", indentString(cmd.Example, "   ")))
 	}
 
 	if hasRelatedCommands(cmd) {


### PR DESCRIPTION
Indent examples two more spaces so that the RST is valid.
Discovered this in https://github.com/mongodb/mongocli/pull/833/