### PR TITLE
(DOCSP-23862) Adds a comment to the autogenerated docs for parsing code block

### DIFF
--- a/cobra2snooty.go
+++ b/cobra2snooty.go
@@ -112,6 +112,7 @@ func GenDocs(cmd *cobra.Command, w io.Writer) error {
 	if cmd.Runnable() {
 		buf.WriteString(syntaxHeader)
 		buf.WriteString(fmt.Sprintf("\n   %s\n\n", strings.ReplaceAll(cmd.UseLine(), "[flags]", "[options]")))
+		buf.WriteString(".. Code end marker, please don't delete this comment\n\n")
 	}
 	if err := printArgs(buf, cmd); err != nil {
 		return err


### PR DESCRIPTION
## Proposed changes

Docs will be using the autogenerated Atlas CLI command files to create includes in the docs repo that are automatically updated whenever there is an Atlas CLI release. As part of this, we need a way to parse out all content except the code block. This requires a standardized line following the code block, which this comment achieves. 

CC: @melissamahoney-mongodb 

Jira ticket: https://jira.mongodb.org/browse/DOCSP-23862

## Checklist

- [X] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [] I have added tests that prove my fix is effective or that my feature works **N/A but ran make gen-docs and checked outcome**
- [] I have added any necessary documentation (if appropriate) **N/A**
- [] I have run `make fmt` and formatted my code