### PR TITLE
(DOCSP-26197) Changes code block to io-code-block.

### DIFF
--- a/cobra2snooty.go
+++ b/cobra2snooty.go
@@ -75,7 +75,10 @@ const syntaxHeader = `Syntax
 const examplesHeader = `Examples
 --------
 
-.. code-block::
+.. io-code-block::
+   
+   .. input::
+      :language: bash
 `
 
 const tocHeader = `
@@ -121,7 +124,7 @@ func GenDocs(cmd *cobra.Command, w io.Writer) error {
 
 	if len(cmd.Example) > 0 {
 		buf.WriteString(examplesHeader)
-		buf.WriteString(fmt.Sprintf("\n%s\n\n", indentString(cmd.Example, " ")))
+		buf.WriteString(fmt.Sprintf("\n   %s\n\n   .. output::\n      :language: json\n      :visible: false\n\n      output", indentString(cmd.Example, " ")))
 	}
 
 	if hasRelatedCommands(cmd) {


### PR DESCRIPTION
## Proposed changes

**WIP**

**This must be merged together with the DOCSP-26197 PR against the mongodb-atlas-cli repo (in progress).**

The docs team would like to be able to use an io-code-block directive for autogenerated examples instead of a code-block directive. An io-code-block directive would allow us to include output for code examples in the future, but the current PR hides the output until we are ready to display it.

I have tested this locally and confirmed that it formats the results as expected (see screenshot), but it requires changes in the mongodb-atlas-cli repo to change the indentation of the examples since io-code-block indents further than code-block. The PRs must be merged together to avoid breaking the formatting of the examples in the generated rST.

Edit: here's the screenshot, but it looks like :visible: false just collapses the content, it doesn't hide it entirely. I will need to troubleshoot this, so marking this WIP.
<img width="826" alt="Screen Shot 2022-10-28 at 11 33 23 AM" src="https://user-images.githubusercontent.com/82042374/198678942-e9bc5e72-5498-4266-b889-549baba05d77.png">

_Jira ticket: https://jira.mongodb.org/browse/DOCSP-26197


## Checklist

- [X] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [] I have added tests that prove my fix is effective or that my feature works **N/A, tested locally**
- [X] I have added any necessary documentation (if appropriate)
- [] I have run `make fmt` and formatted my code **N/A**