### PR TITLE
(DOCSP-26295) Adds annotations for more than one example

### DIFF
--- a/cobra2snooty.go
+++ b/cobra2snooty.go
@@ -75,7 +75,6 @@ const syntaxHeader = `Syntax
 const examplesHeader = `Examples
 --------
 
-.. code-block::
 `
 
 const tocHeader = `
@@ -93,7 +92,7 @@ func GenDocs(cmd *cobra.Command, w io.Writer) error {
 	name := cmd.CommandPath()
 
 	// Create example substrings
-	s := strings.Split(cmd.Example, "# ")
+	examples := strings.Split(cmd.Example, "# ")
 
 	ref := strings.ReplaceAll(name, " ", separator)
 
@@ -122,40 +121,22 @@ func GenDocs(cmd *cobra.Command, w io.Writer) error {
 	}
 	printOptions(buf, cmd)
 
-	if len(s) > 0 && len(s) < 2 {
-		if len(cmd.Example) > 0 {
-			buf.WriteString(examplesHeader)
-			buf.WriteString(fmt.Sprintf("\n%s\n", indentString(cmd.Example, " ")))
-		}
-	}
-
-	if len(s) > 1 {
+	// If it has an example but there's no #, print the example. If there's no example, don't print.
+	if len(examples) == 1 && len(cmd.Example) > 0 {
 		buf.WriteString(examplesHeader)
-		buf.WriteString(fmt.Sprintf("\n   #%s\n", indentString(s[1], " ")))
-	}
-
-	if len(s) > 2 {
 		buf.WriteString(`.. code-block::
 `)
-		buf.WriteString(fmt.Sprintf("\n   #%s\n", indentString(s[2], " ")))
+		buf.WriteString(fmt.Sprintf("\n%s\n", indentString(cmd.Example, " ")))
 	}
 
-	if len(s) > 3 {
-		buf.WriteString(`.. code-block::
-`)
-		buf.WriteString(fmt.Sprintf("\n   #%s\n", indentString(s[3], " ")))
-	}
-
-	if len(s) > 4 {
-		buf.WriteString(`.. code-block::
-`)
-		buf.WriteString(fmt.Sprintf("\n   #%s\n", indentString(s[4], " ")))
-	}
-
-	if len(s) > 5 {
-		buf.WriteString(`.. code-block::
-`)
-		buf.WriteString(fmt.Sprintf("\n   #%s\n", indentString(s[5], " ")))
+	// If it has an example with a #, print the header, then print each in a code block.
+	if len(examples) > 1 {
+		buf.WriteString(examplesHeader)
+		for _, example := range examples[1:] {
+			buf.WriteString(`.. code-block::
+			`)
+			buf.WriteString(fmt.Sprintf("\n   #%s\n", indentString(example, " ")))
+		}
 	}
 
 	if hasRelatedCommands(cmd) {

--- a/cobra2snooty.go
+++ b/cobra2snooty.go
@@ -120,18 +120,14 @@ func GenDocs(cmd *cobra.Command, w io.Writer) error {
 
 	if cmd.Example != "" {
 		// Create example substrings
-		examples := strings.Split(cmd.Example, "# ")
+		examplestrimmed := strings.TrimLeft(cmd.Example, "  #")
+		examples := strings.Split(examplestrimmed, "# ")
 		buf.WriteString(examplesHeader)
-		if len(examples) == 1 { // If it has an example but there's no #, print the example. If there's no example, don't print.
+		// If it has an example, print the header, then print each in a code block.
+		for _, example := range examples[0:] {
 			buf.WriteString(`.. code-block::
-`)
-			buf.WriteString(fmt.Sprintf("\n%s\n", indentString(cmd.Example, " ")))
-		} else { // If it has an example with a #, print the header, then print each in a code block.
-			for _, example := range examples[1:] {
-				buf.WriteString(`.. code-block::
 			`)
-				buf.WriteString(fmt.Sprintf("\n   #%s\n", indentString(example, " ")))
-			}
+			buf.WriteString(fmt.Sprintf("\n   #%s\n", indentString(example, " ")))
 		}
 	}
 

--- a/cobra2snooty.go
+++ b/cobra2snooty.go
@@ -92,6 +92,9 @@ func GenDocs(cmd *cobra.Command, w io.Writer) error {
 	buf := new(bytes.Buffer)
 	name := cmd.CommandPath()
 
+	// Create example substrings
+	s := strings.Split(cmd.Example, "# ")
+
 	ref := strings.ReplaceAll(name, " ", separator)
 
 	buf.WriteString(".. _" + ref + ":\n\n")
@@ -119,33 +122,40 @@ func GenDocs(cmd *cobra.Command, w io.Writer) error {
 	}
 	printOptions(buf, cmd)
 
-	if len(cmd.Example) > 0 {
+	if len(s) > 0 && len(s) < 2 {
+		if len(cmd.Example) > 0 {
+			buf.WriteString(examplesHeader)
+			buf.WriteString(fmt.Sprintf("\n%s\n", indentString(cmd.Example, " ")))
+		}
+	}
+
+	if len(s) > 1 {
 		buf.WriteString(examplesHeader)
-		buf.WriteString(fmt.Sprintf("\n%s\n\n", indentString(cmd.Example, " ")))
+		buf.WriteString(fmt.Sprintf("\n   #%s\n", indentString(s[1], " ")))
 	}
 
-	if len(cmd.Annotations["Example2"]) > 0 {
+	if len(s) > 2 {
 		buf.WriteString(`.. code-block::
 `)
-		buf.WriteString(fmt.Sprintf("\n%s\n\n", indentString(cmd.Annotations["Example2"], " ")))
+		buf.WriteString(fmt.Sprintf("\n   #%s\n", indentString(s[2], " ")))
 	}
 
-	if len(cmd.Annotations["Example3"]) > 0 {
+	if len(s) > 3 {
 		buf.WriteString(`.. code-block::
 `)
-		buf.WriteString(fmt.Sprintf("\n%s\n\n", indentString(cmd.Annotations["Example3"], " ")))
+		buf.WriteString(fmt.Sprintf("\n   #%s\n", indentString(s[3], " ")))
 	}
 
-	if len(cmd.Annotations["Example4"]) > 0 {
+	if len(s) > 4 {
 		buf.WriteString(`.. code-block::
 `)
-		buf.WriteString(fmt.Sprintf("\n%s\n\n", indentString(cmd.Annotations["Example4"], " ")))
+		buf.WriteString(fmt.Sprintf("\n   #%s\n", indentString(s[4], " ")))
 	}
 
-	if len(cmd.Annotations["Example5"]) > 0 {
+	if len(s) > 5 {
 		buf.WriteString(`.. code-block::
 `)
-		buf.WriteString(fmt.Sprintf("\n%s\n\n", indentString(cmd.Annotations["Example5"], " ")))
+		buf.WriteString(fmt.Sprintf("\n   #%s\n", indentString(s[5], " ")))
 	}
 
 	if hasRelatedCommands(cmd) {

--- a/cobra2snooty.go
+++ b/cobra2snooty.go
@@ -72,11 +72,6 @@ const syntaxHeader = `Syntax
 .. code-block::
 `
 
-const examplesHeader = `Examples
---------
-
-`
-
 const tocHeader = `
 .. toctree::
    :titlesonly:
@@ -119,16 +114,7 @@ func GenDocs(cmd *cobra.Command, w io.Writer) error {
 	printOptions(buf, cmd)
 
 	if cmd.Example != "" {
-		// Create example substrings
-		examplestrimmed := strings.TrimLeft(cmd.Example, "  #")
-		examples := strings.Split(examplestrimmed, "# ")
-		buf.WriteString(examplesHeader)
-		// If it has an example, print the header, then print each in a code block.
-		for _, example := range examples[0:] {
-			buf.WriteString(`.. code-block::
-			`)
-			buf.WriteString(fmt.Sprintf("\n   #%s\n", indentString(example, " ")))
-		}
+		printExamples(buf, cmd)
 	}
 
 	if hasRelatedCommands(cmd) {

--- a/cobra2snooty.go
+++ b/cobra2snooty.go
@@ -124,6 +124,30 @@ func GenDocs(cmd *cobra.Command, w io.Writer) error {
 		buf.WriteString(fmt.Sprintf("\n%s\n\n", indentString(cmd.Example, " ")))
 	}
 
+	if len(cmd.Annotations["Example2"]) > 0 {
+		buf.WriteString(`.. code-block::
+`)
+		buf.WriteString(fmt.Sprintf("\n%s\n\n", indentString(cmd.Annotations["Example2"], " ")))
+	}
+
+	if len(cmd.Annotations["Example3"]) > 0 {
+		buf.WriteString(`.. code-block::
+`)
+		buf.WriteString(fmt.Sprintf("\n%s\n\n", indentString(cmd.Annotations["Example3"], " ")))
+	}
+
+	if len(cmd.Annotations["Example4"]) > 0 {
+		buf.WriteString(`.. code-block::
+`)
+		buf.WriteString(fmt.Sprintf("\n%s\n\n", indentString(cmd.Annotations["Example4"], " ")))
+	}
+
+	if len(cmd.Annotations["Example5"]) > 0 {
+		buf.WriteString(`.. code-block::
+`)
+		buf.WriteString(fmt.Sprintf("\n%s\n\n", indentString(cmd.Annotations["Example5"], " ")))
+	}
+
 	if hasRelatedCommands(cmd) {
 		buf.WriteString("Related Commands\n")
 		buf.WriteString("----------------\n\n")

--- a/cobra2snooty.go
+++ b/cobra2snooty.go
@@ -91,9 +91,6 @@ func GenDocs(cmd *cobra.Command, w io.Writer) error {
 	buf := new(bytes.Buffer)
 	name := cmd.CommandPath()
 
-	// Create example substrings
-	examples := strings.Split(cmd.Example, "# ")
-
 	ref := strings.ReplaceAll(name, " ", separator)
 
 	buf.WriteString(".. _" + ref + ":\n\n")
@@ -121,21 +118,20 @@ func GenDocs(cmd *cobra.Command, w io.Writer) error {
 	}
 	printOptions(buf, cmd)
 
-	// If it has an example but there's no #, print the example. If there's no example, don't print.
-	if len(examples) == 1 && len(cmd.Example) > 0 {
+	if cmd.Example != "" {
+		// Create example substrings
+		examples := strings.Split(cmd.Example, "# ")
 		buf.WriteString(examplesHeader)
-		buf.WriteString(`.. code-block::
-`)
-		buf.WriteString(fmt.Sprintf("\n%s\n", indentString(cmd.Example, " ")))
-	}
-
-	// If it has an example with a #, print the header, then print each in a code block.
-	if len(examples) > 1 {
-		buf.WriteString(examplesHeader)
-		for _, example := range examples[1:] {
+		if len(examples) == 1 { // If it has an example but there's no #, print the example. If there's no example, don't print.
 			buf.WriteString(`.. code-block::
+`)
+			buf.WriteString(fmt.Sprintf("\n%s\n", indentString(cmd.Example, " ")))
+		} else { // If it has an example with a #, print the header, then print each in a code block.
+			for _, example := range examples[1:] {
+				buf.WriteString(`.. code-block::
 			`)
-			buf.WriteString(fmt.Sprintf("\n   #%s\n", indentString(example, " ")))
+				buf.WriteString(fmt.Sprintf("\n   #%s\n", indentString(example, " ")))
+			}
 		}
 	}
 

--- a/cobra2snooty_test.go
+++ b/cobra2snooty_test.go
@@ -71,7 +71,10 @@ func Echo() *cobra.Command {
 		Aliases: []string{"say"},
 		Short:   "Echo anything to the screen",
 		Long:    "an utterly useless command for testing",
-		Example: "Just run root echo",
+		Example: map[string]string{
+			"IntroText":   "# Example with intro text",
+			"NoIntroText": "atlas command no intro text",
+		},
 		Annotations: map[string]string{
 			"string to printDesc": "A string to print",
 			"test paramDesc":      "just for testing",
@@ -130,6 +133,10 @@ func TestGenDocs(t *testing.T) {
 
 	checkStringContains(t, output, Echo().Long)
 	checkStringContains(t, output, Echo().Example)
+	checkStringContains(t, output, fmt.Sprintf(`.. code-block::
+	\n   %s\n`, Echo().Example[IntroText]))
+	checkStringContains(t, output, fmt.Sprintf(`.. code-block::
+	\n   #%s\n`, Echo().Example[NoIntroText]))
 	checkStringContains(t, output, "boolone")
 	checkStringContains(t, output, "rootflag")
 	//

--- a/cobra2snooty_test.go
+++ b/cobra2snooty_test.go
@@ -71,7 +71,7 @@ func Echo() *cobra.Command {
 		Aliases: []string{"say"},
 		Short:   "Echo anything to the screen",
 		Long:    "an utterly useless command for testing",
-		Example: "  # Example with intro text\n  atlas command no intro text\n",
+		Example: " # Example with intro text\n  atlas command no intro text\n",
 		Annotations: map[string]string{
 			"string to printDesc": "A string to print",
 			"test paramDesc":      "just for testing",
@@ -129,8 +129,7 @@ func TestGenDocs(t *testing.T) {
 	output := buf.String()
 
 	checkStringContains(t, output, Echo().Long)
-	checkStringContains(t, output, Echo().Example)
-	checkStringContains(t, output, fmt.Sprintf(`.. code-block::\n  # Example with intro text\n\n`))
+	checkStringContains(t, output, fmt.Sprintf(".. code-block::\n%s", Echo().Example))
 	checkStringContains(t, output, "boolone")
 	checkStringContains(t, output, "rootflag")
 	//

--- a/cobra2snooty_test.go
+++ b/cobra2snooty_test.go
@@ -129,7 +129,11 @@ func TestGenDocs(t *testing.T) {
 	output := buf.String()
 
 	checkStringContains(t, output, Echo().Long)
-	checkStringContains(t, output, fmt.Sprintf(".. code-block::\n%s", Echo().Example))
+	checkStringContains(t, output, `.. code-block::
+
+   # Example with intro text
+   atlas command no intro text
+`)
 	checkStringContains(t, output, "boolone")
 	checkStringContains(t, output, "rootflag")
 	//
@@ -154,7 +158,11 @@ func TestGenDocsNoHiddenParents(t *testing.T) {
 	output := buf.String()
 
 	checkStringContains(t, output, Echo().Long)
-	checkStringContains(t, output, Echo().Example)
+	checkStringContains(t, output, `.. code-block::
+
+   # Example with intro text
+   atlas command no intro text
+`)
 	checkStringContains(t, output, "boolone")
 	checkStringOmits(t, output, "rootflag")
 	checkStringOmits(t, output, Root().Short)

--- a/cobra2snooty_test.go
+++ b/cobra2snooty_test.go
@@ -71,10 +71,7 @@ func Echo() *cobra.Command {
 		Aliases: []string{"say"},
 		Short:   "Echo anything to the screen",
 		Long:    "an utterly useless command for testing",
-		Example: map[string]string{
-			"IntroText":   "# Example with intro text",
-			"NoIntroText": "atlas command no intro text",
-		},
+		Example: "  # Example with intro text\n  atlas command no intro text\n",
 		Annotations: map[string]string{
 			"string to printDesc": "A string to print",
 			"test paramDesc":      "just for testing",
@@ -133,10 +130,7 @@ func TestGenDocs(t *testing.T) {
 
 	checkStringContains(t, output, Echo().Long)
 	checkStringContains(t, output, Echo().Example)
-	checkStringContains(t, output, fmt.Sprintf(`.. code-block::
-	\n   %s\n`, Echo().Example[IntroText]))
-	checkStringContains(t, output, fmt.Sprintf(`.. code-block::
-	\n   #%s\n`, Echo().Example[NoIntroText]))
+	checkStringContains(t, output, fmt.Sprintf(`.. code-block::\n  # Example with intro text\n\n`))
 	checkStringContains(t, output, "boolone")
 	checkStringContains(t, output, "rootflag")
 	//

--- a/examples.go
+++ b/examples.go
@@ -1,0 +1,51 @@
+// Copyright 2022 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cobra2snooty
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+const examplesHeader = `Examples
+--------
+
+`
+
+func printExamples(buf *bytes.Buffer, cmd *cobra.Command) error {
+	// Create example substrings
+	examplestrimmed := strings.TrimLeft(cmd.Example, "  #")
+	examples := strings.Split(examplestrimmed, "# ")
+	buf.WriteString(examplesHeader)
+	// If it has an example, print the header, then print each in a code block.
+	for _, example := range examples[0:] {
+		if !strings.Contains(cmd.Example, "#") {
+			buf.WriteString(`.. code-block::
+			`)
+			buf.WriteString(fmt.Sprintf("\n   %s\n", indentString(example, " ")))
+		}
+		if strings.Contains(cmd.Example, "#") {
+
+			buf.WriteString(`.. code-block::
+	`)
+			buf.WriteString(fmt.Sprintf("\n   #%s\n", indentString(example, " ")))
+		}
+	}
+
+	return nil
+}

--- a/examples.go
+++ b/examples.go
@@ -27,9 +27,9 @@ const examplesHeader = `Examples
 
 `
 
-func printExamples(buf *bytes.Buffer, cmd *cobra.Command) error {
+func printExamples(buf *bytes.Buffer, cmd *cobra.Command) {
 	// Create example substrings
-	examplestrimmed := strings.TrimLeft(cmd.Example, "  #")
+	examplestrimmed := strings.TrimLeft(cmd.Example, " #")
 	examples := strings.Split(examplestrimmed, "# ")
 	buf.WriteString(examplesHeader)
 	// If it has an example, print the header, then print each in a code block.
@@ -37,15 +37,12 @@ func printExamples(buf *bytes.Buffer, cmd *cobra.Command) error {
 		if !strings.Contains(cmd.Example, "#") {
 			buf.WriteString(`.. code-block::
 `)
-			buf.WriteString(fmt.Sprintf("\n   %s\n", indentString(example, " ")))
+			buf.WriteString(fmt.Sprintf("\n  %s\n", indentString(example, " ")))
 		}
 		if strings.Contains(cmd.Example, "#") {
-
 			buf.WriteString(`.. code-block::
 `)
 			buf.WriteString(fmt.Sprintf("\n   #%s\n", indentString(example, " ")))
 		}
 	}
-
-	return nil
 }

--- a/examples.go
+++ b/examples.go
@@ -36,13 +36,13 @@ func printExamples(buf *bytes.Buffer, cmd *cobra.Command) error {
 	for _, example := range examples[0:] {
 		if !strings.Contains(cmd.Example, "#") {
 			buf.WriteString(`.. code-block::
-			`)
+`)
 			buf.WriteString(fmt.Sprintf("\n   %s\n", indentString(example, " ")))
 		}
 		if strings.Contains(cmd.Example, "#") {
 
 			buf.WriteString(`.. code-block::
-	`)
+`)
 			buf.WriteString(fmt.Sprintf("\n   #%s\n", indentString(example, " ")))
 		}
 	}

--- a/examples.go
+++ b/examples.go
@@ -22,10 +22,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const examplesHeader = `Examples
+const (
+	examplesHeader = `Examples
 --------
 
 `
+	identChar = " "
+)
 
 func printExamples(buf *bytes.Buffer, cmd *cobra.Command) {
 	// Create example substrings
@@ -34,15 +37,12 @@ func printExamples(buf *bytes.Buffer, cmd *cobra.Command) {
 	buf.WriteString(examplesHeader)
 	// If it has an example, print the header, then print each in a code block.
 	for _, example := range examples[0:] {
-		if !strings.Contains(cmd.Example, "#") {
-			buf.WriteString(`.. code-block::
-`)
-			buf.WriteString(fmt.Sprintf("\n  %s\n", indentString(example, " ")))
-		}
+		comment := ""
 		if strings.Contains(cmd.Example, "#") {
-			buf.WriteString(`.. code-block::
-`)
-			buf.WriteString(fmt.Sprintf("\n   #%s\n", indentString(example, " ")))
+			comment = "#"
 		}
+		buf.WriteString(`.. code-block::
+`)
+		buf.WriteString(fmt.Sprintf("\n   %s%s\n", comment, indentString(example, identChar)))
 	}
 }


### PR DESCRIPTION
## Proposed changes

We decided to hold off on doing io-code-blocks with outputs for now, but I still wanted to make a few improvements to the way we show examples in the autogenerated docs. These changes add annotations for additional examples, which will display in their own code block. An additional PR has been filed for mongodb-atlas-cli, but that PR needs to be rebased after this one merges.

I have tested this change locally.

_Jira ticket: https://jira.mongodb.org/browse/DOCSP-26295

## Checklist

- [] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [] I have added tests that prove my fix is effective or that my feature works
- [] I have added any necessary documentation (if appropriate)
- [] I have run `make fmt` and formatted my code