### PR TITLE
(DOCSP-26295) Fixes incorrect spacing for commands without #

### DIFF
--- a/cobra2snooty_test.go
+++ b/cobra2snooty_test.go
@@ -71,7 +71,7 @@ func Echo() *cobra.Command {
 		Aliases: []string{"say"},
 		Short:   "Echo anything to the screen",
 		Long:    "an utterly useless command for testing",
-		Example: " # Example with intro text\n  atlas command no intro text\n",
+		Example: " # Example with intro text\n atlas command no intro text\n",
 		Annotations: map[string]string{
 			"string to printDesc": "A string to print",
 			"test paramDesc":      "just for testing",

--- a/cobra2snooty_test.go
+++ b/cobra2snooty_test.go
@@ -129,10 +129,9 @@ func TestGenDocs(t *testing.T) {
 	output := buf.String()
 
 	checkStringContains(t, output, Echo().Long)
-	checkStringContains(t, output, `.. code-block::
-
-   # Example with intro text
-   atlas command no intro text
+	checkStringContains(t, output, `
+  # Example with intro text
+  atlas command no intro text
 `)
 	checkStringContains(t, output, "boolone")
 	checkStringContains(t, output, "rootflag")
@@ -158,10 +157,9 @@ func TestGenDocsNoHiddenParents(t *testing.T) {
 	output := buf.String()
 
 	checkStringContains(t, output, Echo().Long)
-	checkStringContains(t, output, `.. code-block::
-
-   # Example with intro text
-   atlas command no intro text
+	checkStringContains(t, output, `
+  # Example with intro text
+  atlas command no intro text
 `)
 	checkStringContains(t, output, "boolone")
 	checkStringOmits(t, output, "rootflag")

--- a/examples.go
+++ b/examples.go
@@ -43,6 +43,6 @@ func printExamples(buf *bytes.Buffer, cmd *cobra.Command) {
 		}
 		buf.WriteString(`.. code-block::
 `)
-		buf.WriteString(fmt.Sprintf("\n   %s%s\n", comment, indentString(example, identChar)))
+		buf.WriteString(fmt.Sprintf("\n  %s%s\n", comment, indentString(example, identChar)))
 	}
 }


### PR DESCRIPTION
## Proposed changes

The [last commit on the PR merged today](https://github.com/mongodb-labs/cobra2snooty/pull/26/commits/3926454fa93da069303a81556bd24c37d85d69b4) changed the spacing of the commands without intro text. This PR fixes it. Sorry for not catching when I reviewed that commit.

_Jira ticket:_ 

<!--
What MongoDB Ops Manager Go Client issue does this PR address? (for example, #1234), remove this section if none
-->

Closes #[issue number]

## Checklist

- [] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [] I have added tests that prove my fix is effective or that my feature works
- [] I have added any necessary documentation (if appropriate)
- [] I have run `make fmt` and formatted my code