### PR TITLE
(DOCSP-26295) Fixes incorrect indentation on examples

### DIFF
--- a/cobra2snooty_test.go
+++ b/cobra2snooty_test.go
@@ -71,7 +71,7 @@ func Echo() *cobra.Command {
 		Aliases: []string{"say"},
 		Short:   "Echo anything to the screen",
 		Long:    "an utterly useless command for testing",
-		Example: " # Example with intro text\n atlas command no intro text\n",
+		Example: "# Example with intro text\n atlas command no intro text\n",
 		Annotations: map[string]string{
 			"string to printDesc": "A string to print",
 			"test paramDesc":      "just for testing",
@@ -129,8 +129,7 @@ func TestGenDocs(t *testing.T) {
 	output := buf.String()
 
 	checkStringContains(t, output, Echo().Long)
-	checkStringContains(t, output, `
-  # Example with intro text
+	checkStringContains(t, output, `# Example with intro text
   atlas command no intro text
 `)
 	checkStringContains(t, output, "boolone")
@@ -157,8 +156,7 @@ func TestGenDocsNoHiddenParents(t *testing.T) {
 	output := buf.String()
 
 	checkStringContains(t, output, Echo().Long)
-	checkStringContains(t, output, `
-  # Example with intro text
+	checkStringContains(t, output, `# Example with intro text
   atlas command no intro text
 `)
 	checkStringContains(t, output, "boolone")

--- a/examples.go
+++ b/examples.go
@@ -39,7 +39,7 @@ func printExamples(buf *bytes.Buffer, cmd *cobra.Command) {
 	for _, example := range examples[0:] {
 		comment := ""
 		if strings.Contains(cmd.Example, "#") {
-			comment = "#"
+			comment = " #"
 		}
 		buf.WriteString(`.. code-block::
 `)


### PR DESCRIPTION
## Proposed changes

Testing this change locally corrects the spacing for commands with:
-No example
-1 example, no # symbol
-1 or more examples with # symbol

See screen shots below

_Jira ticket:_ 

https://jira.mongodb.org/browse/DOCSP-26295

Closes #[issue number]

## Checklist

- [] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [] I have added tests that prove my fix is effective or that my feature works
- [] I have added any necessary documentation (if appropriate)
- [] I have run `make fmt` and formatted my code

## Further comments

![MultiExampleWith#](https://user-images.githubusercontent.com/82042374/202178300-19687f75-8c1e-41dc-8166-008dc731d826.png)

---

![1ExampleWith#](https://user-images.githubusercontent.com/82042374/202178301-ffaae693-3b71-41de-8065-b8d758eeaf9a.png)

---

![1ExampleNo#](https://user-images.githubusercontent.com/82042374/202178302-ee6e2030-9390-4ec5-aa8f-be757ef5a281.png)

---

![NoExamples](https://user-images.githubusercontent.com/82042374/202178303-c19a4083-3692-48a1-9558-499dc88e0994.png)

