### PR TITLE
Adds line to template for custom role annotation

### DIFF
--- a/cobra2snooty.go
+++ b/cobra2snooty.go
@@ -101,9 +101,8 @@ func GenDocs(cmd *cobra.Command, w io.Writer) error {
 		}
 		buf.WriteString("\n" + long + "\n")
 	}
-	if cmd.Annotations["requiredRole"] != "" {
-		buf.WriteString("\nTo use this command, the requesting user or API key must have the " + cmd.Annotations["requiredRole"] + " role.\n")
-	}
+
+	requiredRole(buf, cmd)
 	buf.WriteString("\n")
 
 	if cmd.Runnable() {

--- a/cobra2snooty.go
+++ b/cobra2snooty.go
@@ -101,6 +101,9 @@ func GenDocs(cmd *cobra.Command, w io.Writer) error {
 		}
 		buf.WriteString("\n" + long + "\n")
 	}
+	if cmd.Annotations["requiredRole"] != "" {
+		buf.WriteString("\nTo use this command, the requesting user or API key must have the " + cmd.Annotations["requiredRole"] + " role.\n")
+	}
 	buf.WriteString("\n")
 
 	if cmd.Runnable() {

--- a/requiredRole.go
+++ b/requiredRole.go
@@ -1,0 +1,27 @@
+// Copyright 2022 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cobra2snooty
+
+import (
+	"bytes"
+
+	"github.com/spf13/cobra"
+)
+
+func requiredRole(buf *bytes.Buffer, cmd *cobra.Command) {
+	if cmd.Annotations["requiredRole"] != "" {
+		buf.WriteString("\nTo use this command, the requesting user or API key must have the " + cmd.Annotations["requiredRole"] + " role.\n")
+	}
+}


### PR DESCRIPTION
## Proposed changes

We have info on the roles required for all commands in the OpenAPI spec. When I started the MCLI backfill, I planned to explore ways we might programmatically pull this info in rather than adding it manually. 

After some research, it seems that we do need to add the roles manually, but I think that the best way to do this is by standardizing the language at the cobra2snooty template level, adding a new custom annotation for requiredRole to each command, and having the info display for all commands with the annotation after the Long description. This also aligns with a new ask we have this quarter to make sure that all pages for the UI include info on required roles to perform actions.

If we choose to merge this PR, I can add all of the requiredRoles annotations for Atlas commands.

I tested this locally and results display as expected for commands with a requiredRole annotation and don't display for commands without it. See the highlighted line on the attached screenshot for how it displays on an autogenerated docs page.
![Screen Shot 2023-02-08 at 6 48 21 AM](https://user-images.githubusercontent.com/82042374/217521749-00ace9fc-9a16-4c18-b519-75b91adc9b8d.png)
![Screen Shot 2023-02-08 at 6 52 07 AM](https://user-images.githubusercontent.com/82042374/217522387-8931f56f-d8d8-4888-9ebd-f2bc4245cf2f.png)


_Jira ticket:_ 

N/A

## Checklist

- [X] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [] I have added tests that prove my fix is effective or that my feature works
- [X] I have added any necessary documentation (if appropriate)
- [] I have run `make fmt` and formatted my code
