### PR TITLE
Adds an output to docs files

### DIFF
--- a/cobra2snooty.go
+++ b/cobra2snooty.go
@@ -115,6 +115,9 @@ func GenDocs(cmd *cobra.Command, w io.Writer) error {
 	}
 	printOptions(buf, cmd)
 
+	printOutputCreate(buf, cmd)
+	buf.WriteString("\n")
+
 	if cmd.Example != "" {
 		printExamples(buf, cmd)
 	}

--- a/output.go
+++ b/output.go
@@ -1,0 +1,64 @@
+// Copyright 2022 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cobra2snooty
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	outputHeader = `Output
+------
+`
+)
+
+// This function can return the output for create and delete commands when the output template is added as an annotation in the command file
+
+func printOutputCreate(buf *bytes.Buffer, cmd *cobra.Command) {
+	removerange := strings.ReplaceAll(cmd.Annotations["output"], "{{range .Results}}", "")
+	removeend := strings.ReplaceAll(removerange, "{{end}}", "")
+	bracketsremoved1 := strings.ReplaceAll(removeend, "{{.", "<")
+	bracketsremoved2 := strings.ReplaceAll(bracketsremoved1, "}}", ">")
+	replacevariable := strings.ReplaceAll(bracketsremoved2, "%s", "<Name>")
+	replacevariable2 := strings.ReplaceAll(replacevariable, "\n", "\n   ")
+	w := new(tabwriter.Writer)
+	w.Init(buf, 0, 0, 0, ' ', tabwriter.Debug|tabwriter.AlignRight)
+
+	if cmd.Annotations["output"] == "" {
+		return
+	}
+
+	buf.WriteString(outputHeader)
+	buf.WriteString(`
+If the command succeeds, the CLI prints a message similar to the following and replaces the values in brackets with your values. The | symbol represents a horizontal tab.
+
+.. code-block::
+
+`)
+	if strings.HasSuffix(cmd.Annotations["output"], "}"+"\n") {
+		fmt.Fprintln(w, replacevariable2)
+		w.Flush()
+	} else {
+		buf.WriteString("   ")
+		fmt.Fprintln(w, replacevariable2)
+		w.Flush()
+	}
+	buf.WriteString("\n")
+}


### PR DESCRIPTION
## Proposed changes

This experimental PR adds an output section to the docs files. It would depend on an "output" annotation, which would use the template already defined in each file (listTemplate, describeTemplate, etc) that reflects the output in the CLI itself.

I tested this locally and I am including screenshots of create, delete, list, and describe commands after a local test with these changes. I also included a screenshot of what the annotation looks like.

<img width="676" alt="Screenshot 2023-03-12 at 3 12 19 PM" src="https://user-images.githubusercontent.com/82042374/224567878-5c2e8476-a33d-4ba8-8b35-9356bd4d9a54.png">
<img width="683" alt="Screenshot 2023-03-12 at 3 13 00 PM" src="https://user-images.githubusercontent.com/82042374/224567882-9dfec595-6dc4-49e0-9ce7-19135a837830.png">
<img width="678" alt="Screenshot 2023-03-12 at 3 13 23 PM" src="https://user-images.githubusercontent.com/82042374/224567898-e068f459-228b-4a7d-ad39-55598c1261c3.png">
<img width="676" alt="Screenshot 2023-03-12 at 3 14 45 PM" src="https://user-images.githubusercontent.com/82042374/224567904-0df90ffe-38e4-4433-a7eb-a76b1a442fdb.png">
<img width="493" alt="Screenshot 2023-03-12 at 3 23 31 PM" src="https://user-images.githubusercontent.com/82042374/224568025-57da2e63-52d7-4503-81bf-e159ee1236dd.png">

_Jira ticket:_ 

N/A

## Checklist

- [] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [] I have added tests that prove my fix is effective or that my feature works
- [] I have added any necessary documentation (if appropriate)
- [] I have run `make fmt` and formatted my code
