### PR TITLE
(DOCSP-28811) Adds captions that accomodate literal includes for Atlas docs

### DIFF
--- a/cobra2snooty.go
+++ b/cobra2snooty.go
@@ -70,6 +70,7 @@ const syntaxHeader = `Syntax
 ------
 
 .. code-block::
+   :caption: Command Syntax
 `
 
 const tocHeader = `


### PR DESCRIPTION
## Proposed changes

The docs platform team has informed us that we need to use a unique value for the :start-after: option in our literal includes across the Atlas docs. Currently, we use the value "code-block::", which is not unique on each command reference page because that value also appears in the examples. This PR adds a unique value we can use.

_Jira ticket:_ 
https://jira.mongodb.org/browse/DOCSP-28811

## Checklist

- [] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [] I have added tests that prove my fix is effective or that my feature works
- [] I have added any necessary documentation (if appropriate)
- [] I have run `make fmt` and formatted my code

## Further comments

After discussing with @melissamahoney-mongodb, we decided that adding this caption that says Command Syntax would be a good solution that provides a unique value for literal includes. Here is a staged example showing what the command reference pages look like rendered with this caption: https://docs-atlas-staging.mongodb.com/cloud-docs/docsworker-xlarge/DOCSP-28811/includes/command/atlas-accessLists-create/

Once this PR merges, cobra2snooty releases and the newest version is pulled into the mongodb-atlas-cli repo, we will wait for the next Atlas CLI release, then coordinate the changes to the literal includes to happen at the same time that we run docurl to update the command files to avoid errors in the cloud-docs build or the inclusion of the caption option in the code blocks from the literal includes.

