### PR TITLE
(DOCSP-30039) Adds mutually exclusive flag info

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -73,7 +73,17 @@ func FlagUsages(f *pflag.FlagSet) string {
 			}
 		}
 
-		line += "\n    - " + usage
+		mutuale := fmt.Sprintf("%v", flag.Annotations["cobra_annotation_mutually_exclusive"])
+		mutuale = strings.ReplaceAll(mutuale, "]", "")
+		mutuale = strings.ReplaceAll(mutuale, "[", "")
+		mutuale = strings.ReplaceAll(mutuale, flag.Name+" ", "")
+		mutuale = strings.ReplaceAll(mutuale, " "+flag.Name, "")
+		mutuale = strings.ReplaceAll(mutuale, " ", ", --")
+		if len(flag.Annotations["cobra_annotation_mutually_exclusive"]) != 0 {
+			line += "\n    - " + usage + "\n\n      Mutually exclusive with --" + mutuale + "."
+		} else {
+			line += "\n    - " + usage
+		}
 		if !defaultIsZeroValue(flag) {
 			if flag.Value.Type() == stringType {
 				line += fmt.Sprintf(" This value defaults to %q.", flag.DefValue)


### PR DESCRIPTION
## Proposed changes

This PR leverages the mutually exclusive flags specified on some commands to add this info into the flag description for applicable options. There may be a more elegant way to accomplish what I've done here than the series of ReplaceAll strings; if there is, please let me know.

This adds the mutually exclusive info after a line break within the flag description. If there's a default value, it will follow the mutually exclusive flags.

To see a PR with what this change looks like when you run make gen-docs, see this draft PR: https://github.com/mongodb/mongodb-atlas-cli/pull/2013/files

To see what this should look like when staged, see: https://docs-atlas-staging.mongodb.com/cloud-docs/docsworker-xlarge/DOCSP-30039/includes/command/atlas-backups-schedule-update/ Build has no errors with the change staged on that page.

_Jira ticket:_ 

https://jira.mongodb.org/browse/DOCSP-30039

## Checklist

- [] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [] I have added tests that prove my fix is effective or that my feature works
- [] I have added any necessary documentation (if appropriate)
- [] I have run `make fmt` and formatted my code
