### PR TITLE
Fixed issue with default value for 'stringToString'

### DIFF
--- a/cobra2snooty_test.go
+++ b/cobra2snooty_test.go
@@ -80,6 +80,7 @@ func Echo() *cobra.Command {
 	echoCmd.PersistentFlags().BoolP("persistentbool", "p", false, "help message for flag persistentbool")
 	echoCmd.Flags().IntP("intone", "i", 123, "help message for flag intone")
 	echoCmd.Flags().BoolP("boolone", "b", true, "help message for flag boolone")
+	echoCmd.Flags().StringToStringP("stringtostring", "x", nil, "help message for flag stringtostring")
 
 	timesCmd := &cobra.Command{
 		Use:        "times [# times] [string to echo]",
@@ -139,6 +140,9 @@ func TestGenDocs(t *testing.T) {
 	checkStringOmits(t, output, Root().Short)
 	checkStringContains(t, output, EchoSubCmd().Short)
 	checkStringOmits(t, output, deprecatedCmd.Short)
+
+	// Verify that the text "This value defaults to" is not printed when the default value is provided to StringToStringP
+	checkStringContains(t, output, "* - -x, --stringtostring\n     - stringToString\n     - false\n     - help message for flag stringtostring\n   *")
 }
 
 func TestGenDocsNoHiddenParents(t *testing.T) {

--- a/flags.go
+++ b/flags.go
@@ -116,7 +116,7 @@ func defaultIsZeroValue(f *pflag.Flag) bool {
 		return f.DefValue == ""
 	case "ip", "ipMask", "ipNet":
 		return f.DefValue == nilValue
-	case "intSlice", "stringSlice", "stringArray":
+	case "intSlice", "stringSlice", "stringArray", "stringToString":
 		return f.DefValue == "[]"
 	default:
 		switch f.Value.String() {


### PR DESCRIPTION
## Proposed changes

In this PR: https://github.com/mongodb/mongodb-atlas-cli/pull/2666

@sarahsimpers noticed that when the default is provided to `StringToStringP` the generated snooty code still prints `This value defaults to: []`. This PR fixes that.