### PR TITLE
CLOUDP-230973: Print 'string' as type for 'stringToString'

### DIFF
--- a/cobra2snooty_test.go
+++ b/cobra2snooty_test.go
@@ -142,7 +142,7 @@ func TestGenDocs(t *testing.T) {
 	checkStringOmits(t, output, deprecatedCmd.Short)
 
 	// Verify that the text "This value defaults to" is not printed when the default value is provided to StringToStringP
-	checkStringContains(t, output, "* - -x, --stringtostring\n     - stringToString\n     - false\n     - help message for flag stringtostring\n   *")
+	checkStringContains(t, output, "* - -x, --stringtostring\n     - string\n     - false\n     - help message for flag stringtostring\n   *")
 }
 
 func TestGenDocsNoHiddenParents(t *testing.T) {

--- a/flags.go
+++ b/flags.go
@@ -31,6 +31,12 @@ const (
 	nilValue   = "<nil>"
 )
 
+var (
+	varnameMap = map[string]string{
+		"stringToString": "string",
+	}
+)
+
 func FlagUsages(f *pflag.FlagSet) string {
 	buf := new(bytes.Buffer)
 
@@ -41,6 +47,7 @@ func FlagUsages(f *pflag.FlagSet) string {
 
 		line := ""
 		varname, usage := pflag.UnquoteUsage(flag)
+		varname = mapVarname(varname)
 		const defaultIndentation = 6
 		usage = strings.ReplaceAll(usage, "\n", "\n"+strings.Repeat(" ", defaultIndentation))
 
@@ -131,4 +138,13 @@ func defaultIsZeroValue(f *pflag.Flag) bool {
 		}
 		return false
 	}
+}
+
+func mapVarname(varname string) string {
+	mapped, found := varnameMap[varname]
+	if !found {
+		return varname
+	}
+
+	return mapped
 }


### PR DESCRIPTION
## Proposed changes

Print `string` as type for `stringToString` instead of `stringToString`

_Jira ticket: CLOUDP-230973