### PR TITLE
CLOUDP-230973: Changed 'string' to 'key=value' for StringToString

### DIFF
--- a/cobra2snooty_test.go
+++ b/cobra2snooty_test.go
@@ -142,7 +142,7 @@ func TestGenDocs(t *testing.T) {
 	checkStringOmits(t, output, deprecatedCmd.Short)
 
 	// Verify that the text "This value defaults to" is not printed when the default value is provided to StringToStringP
-	checkStringContains(t, output, "* - -x, --stringtostring\n     - string\n     - false\n     - help message for flag stringtostring\n   *")
+	checkStringContains(t, output, "* - -x, --stringtostring\n     - key=value\n     - false\n     - help message for flag stringtostring\n   *")
 }
 
 func TestGenDocsNoHiddenParents(t *testing.T) {

--- a/flags.go
+++ b/flags.go
@@ -33,7 +33,7 @@ const (
 
 var (
 	varnameMap = map[string]string{
-		"stringToString": "string",
+		"stringToString": "key=value",
 	}
 )
 


### PR DESCRIPTION
## Proposed changes

Changed `string` to `key=value` for StringToString
_Jira ticket: CLOUDP-230973_ 
