### PR TITLE
task: fix golangci lint config

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,7 +19,7 @@ jobs:
       - name: lint
         uses: golangci/golangci-lint-action@v5.1.0
         with:
-          version: v1.56.1
+          version: v1.56.2
 
   tests-on-unix:
     needs: golangci-lint # run after golangci-lint action to not produce duplicated errors

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,16 +11,8 @@ linters-settings:
   gocyclo:
     min-complexity: 16
   govet:
-    check-shadowing: true
-  maligned:
-    suggest-new: true
-  tagliatelle:
-    # check the struck tag name case
-    case:
-      use-field-name: true
-      rules:
-        json: camel
-        yaml: camel
+    enable:
+      - shadow
   revive:
     # see https://github.com/mgechev/revive#available-rules for details.
     ignore-generated-header: true
@@ -60,7 +52,6 @@ linters:
   disable-all: true
   enable:
     - bodyclose # checks whether HTTP response body is closed successfully [fast: false, auto-fix: false]
-
     - dogsled # Checks assignments with too many blank identifiers (e.g. x, _, _, _, := f()) [fast: true, auto-fix: false]
     - errcheck # Errcheck is a program for checking for unchecked errors in go programs. These unchecked errors can be critical bugs in some cases [fast: false, auto-fix: false]
     - errorlint # errorlint is a linter for that can be used to find code that will cause problems with the error wrapping scheme introduced in Go 1.13. [fast: false, auto-fix: false]
@@ -85,13 +76,14 @@ linters:
     - nolintlint # Reports ill-formed or insufficient nolint directives [fast: true, auto-fix: false]
     - revive # Fast, configurable, extensible, flexible, and beautiful linter for Go. Drop-in replacement of golint. [fast: false, auto-fix: false]
     - rowserrcheck # checks whether Err of rows is checked successfully [fast: false, auto-fix: false]
-    - staticcheck  #megacheck): Staticcheck is a go vet on steroids, applying a ton of static analysis checks [fast: false, auto-fix: false]
+    - perfsprint # Checks that fmt.Sprintf can be replaced with a faster alternative.
+    - staticcheck  # megacheck): Staticcheck is a go vet on steroids, applying a ton of static analysis checks [fast: false, auto-fix: false]
     - stylecheck # Stylecheck is a replacement for golint [fast: false, auto-fix: false]
-    - tagliatelle # Checks the struct tags. [fast: true, auto-fix: false]
     - thelper # thelper detects golang test helpers without t.Helper() call and checks the consistency of test helpers [fast: false, auto-fix: false]
     - typecheck # Like the front-end of a Go compiler, parses and type-checks Go code [fast: false, auto-fix: false]
     - unconvert # Remove unnecessary type conversions [fast: false, auto-fix: false]
     - unparam # Reports unused function parameters [fast: false, auto-fix: false]
+    - usestdlibvars # A linter that detect the possibility to use variables/constants from the Go standard library. [fast: true, auto-fix: false]
     - unused # Checks Go code for unused constants, variables, functions and types [fast: false, auto-fix: false]
     - whitespace # Tool for detection of leading and trailing whitespace [fast: true, auto-fix: true]
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -74,9 +74,9 @@ linters:
     - misspell # Finds commonly misspelled English words in comments [fast: true, auto-fix: true]
     - nakedret # Finds naked returns in functions greater than a specified function length [fast: true, auto-fix: false]
     - nolintlint # Reports ill-formed or insufficient nolint directives [fast: true, auto-fix: false]
+    - perfsprint # Checks that fmt.Sprintf can be replaced with a faster alternative.
     - revive # Fast, configurable, extensible, flexible, and beautiful linter for Go. Drop-in replacement of golint. [fast: false, auto-fix: false]
     - rowserrcheck # checks whether Err of rows is checked successfully [fast: false, auto-fix: false]
-    - perfsprint # Checks that fmt.Sprintf can be replaced with a faster alternative.
     - staticcheck  # megacheck): Staticcheck is a go vet on steroids, applying a ton of static analysis checks [fast: false, auto-fix: false]
     - stylecheck # Stylecheck is a replacement for golint [fast: false, auto-fix: false]
     - thelper # thelper detects golang test helpers without t.Helper() call and checks the consistency of test helpers [fast: false, auto-fix: false]

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # A Self-Documenting Makefile: http://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
 
 SOURCE_FILES?=./...
-GOLANGCI_VERSION=v1.56.1
+GOLANGCI_VERSION=v1.56.2
 COVERAGE=coverage.out
 
 export PATH := ./bin:$(PATH)


### PR DESCRIPTION
## Proposed changes

- Update to 1.56.2
- Fix the config for govet
- Remove maligned config since not enabled
- Remove tagliatelle since this lib doens't need it (no serializable structs)
- Enable perfsprint since this lib is mostly string operations and we can benefit of it 